### PR TITLE
camera: Check if aux camera whitelist is set before restricting cameras

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -279,7 +279,9 @@ public class Camera {
     /** @hide */
     public static boolean shouldExposeAuxCamera() {
         String packageName = ActivityThread.currentOpPackageName();
+        // This should be .packagewhitelist but we shouldn't change qualcomm's default
         String packageList = SystemProperties.get("vendor.camera.aux.packagelist");
+        String packageBlacklist = SystemProperties.get("vendor.camera.aux.packageblacklist");
         if (packageList.length() > 0) {
             TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
             splitter.setString(packageList);
@@ -288,8 +290,17 @@ public class Camera {
                     return true;
                 }
             }
+            return false;
+        } else if (packageBlacklist.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageBlacklist);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    return false;
+                }
+            }
         }
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Some devices have a fully featured 3rd camera and adding 20+ camera apps
to the whitelist is impossible due to the string length limit on
systemprops. Add a check to see if the prop is even set, and if not,
check if the blacklist property is set and mark those apps to hide the
3rd camera from. If a package is not part of the blacklist, just restore
the original behaviour and expose all the cameras to the app.

Change-Id: I6c3b33c077e8710c73b5d0fa28e1b017d6c43a58